### PR TITLE
Using secure version for inch-ci.org

### DIFF
--- a/lib/middleman/docsite/project.rb
+++ b/lib/middleman/docsite/project.rb
@@ -80,11 +80,11 @@ module Middleman
       end
 
       def inch_url
-        "http://inch-ci.org/github/#{org}/#{name}"
+        "https://inch-ci.org/github/#{org}/#{name}"
       end
 
       def inch_badge
-        "http://inch-ci.org/github/#{org}/#{name}.svg?branch=master&style=flat"
+        "https://inch-ci.org/github/#{org}/#{name}.svg?branch=master&style=flat"
       end
 
       def api_url


### PR DESCRIPTION
Currently the status page of dry-rb.org is showing a warning:

```
This website contains content that is not secure (such as images)
```
The warning is triggered by the "mixed content" the browser is requesting for the inch-ci.org images, even thou inch-ci.org do the redirection on their side.

With this change, the nagging warning will be gone since all the page will be requesting only secure version (https).